### PR TITLE
Modernize code

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,10 @@ use AltchaOrg\Altcha\Altcha;
 $hmacKey = 'secret hmac key';
 
 // Create a new challenge
-$options = new ChallengeOptions([
-    'hmacKey'   => $hmacKey,
-    'maxNumber' => 50000, // the maximum random number
+$options = new ChallengeOptions(
+    $hmacKey,
+    ChallengeOptions::DEFAULT_ALGORITHM,
+    50000, // the maximum random number
 ]);
 
 $challenge = Altcha::createChallenge($options);
@@ -65,45 +66,36 @@ if ($ok) {
 
 ## API
 
-### `Altcha::createChallenge(array $options): array`
+### `Altcha::createChallenge(ChallengeOptions $options): Challenge`
 
 Creates a new challenge for ALTCHA.
 
-**Parameters:**
+**Returns:** `Challenge`
 
-- `options array`:
-  - `algorithm string`: Hashing algorithm to use (`SHA-1`, `SHA-256`, `SHA-512`, default: `SHA-256`).
-  - `maxNumber int`: Maximum number for the random number generator (default: 1,000,000).
-  - `saltLength int`: Length of the random salt (default: 12 bytes).
-  - `hmacKey string`: Required HMAC key.
-  - `salt string`: Optional salt string. If not provided, a random salt will be generated.
-  - `number int`: Optional specific number to use. If not provided, a random number will be generated.
-  - `expires \DateTime`: Optional expiration time for the challenge.
-  - `params array`: Optional URL-encoded query parameters.
+#### `ChallengeOptions`
 
-**Returns:** `array`
+```php
+$options = new ChallengeOptions(
+    $hmacKey,
+    ChallengeOptions::DEFAULT_ALGORITHM,
+    ChallengeOptions::DEFAULT_MAX_NUMBER,
+    (new \DateTimeImmutable())->add(new \DateInterval('PT10S')),
+    ['query_param' => '123'],
+    ChallengeOptions::DEFAULT_SALT_LENGTH
+]);
+```
 
-### `Altcha::verifySolution(array $payload, string $hmacKey, bool $checkExpires): bool`
+### `Altcha::verifySolution(array|string $payload, string $hmacKey, bool $checkExpires): bool`
 
 Verifies an ALTCHA solution.
 
 **Parameters:**
 
-- `payload array`: The solution payload to verify.
+- `data array|string`: The solution payload to verify.
 - `hmacKey string`: The HMAC key used for verification.
 - `checkExpires bool`: Whether to check if the challenge has expired.
 
 **Returns:** `bool`
-
-### `Altcha::extractParams(array $payload): array`
-
-Extracts URL parameters from the payload's salt.
-
-**Parameters:**
-
-- `payload array`: The payload containing the salt.
-
-**Returns:** `array`
 
 ### `Altcha::verifyFieldsHash(array $formData, array $fields, string $fieldsHash, string $algorithm): bool`
 
@@ -118,18 +110,18 @@ Verifies the hash of form fields.
 
 **Returns:** `bool`
 
-### `Altcha::verifyServerSignature($payload, string $hmacKey): array`
+### `Altcha::verifyServerSignature(array|string $payload, string $hmacKey): ServerSignatureVerification`
 
 Verifies the server signature.
 
 **Parameters:**
 
-- `payload mixed`: The payload to verify (string or `ServerSignaturePayload` array).
+- `data array|string`: The payload to verify (string or `ServerSignaturePayload` array).
 - `hmacKey string`: The HMAC key used for verification.
 
-**Returns:** `array`
+**Returns:** `ServerSignatureVerification`
 
-### `Altcha::solveChallenge(string $challenge, string $salt, string $algorithm, int $max, int $start, $stopChan = null): array`
+### `Altcha::solveChallenge(string $challenge, string $salt, string $algorithm, int $max, int $start = 0): array`
 
 Finds a solution to the given challenge.
 
@@ -141,7 +133,7 @@ Finds a solution to the given challenge.
 - `max int`: Maximum number to iterate to.
 - `start int`: Starting number.
 
-**Returns:** `array`
+**Returns:** `null|Solution`
 
 
 ## Tests

--- a/composer.json
+++ b/composer.json
@@ -14,9 +14,18 @@
         }
     ],
     "require": {
-        "php": ">=7.4"
+        "php": ">=7.4",
+        "ext-json": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "^11.5"
+        "phpunit/phpunit": "^11.5",
+        "phpstan/phpstan": "^2.1",
+        "phpstan/phpstan-phpunit": "^2.0",
+        "phpstan/extension-installer": "^1.4"
+    },
+    "config": {
+        "allow-plugins": {
+            "phpstan/extension-installer": true
+        }
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d73ea3536cd869eb6ae47e1638b6076d",
+    "content-hash": "4215398bfd95a5256d87cf47ad091cb8",
     "packages": [],
     "packages-dev": [
         {
@@ -242,6 +242,163 @@
                 "source": "https://github.com/phar-io/version/tree/3.2.1"
             },
             "time": "2022-02-21T01:04:05+00:00"
+        },
+        {
+            "name": "phpstan/extension-installer",
+            "version": "1.4.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/extension-installer.git",
+                "reference": "85e90b3942d06b2326fba0403ec24fe912372936"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/extension-installer/zipball/85e90b3942d06b2326fba0403ec24fe912372936",
+                "reference": "85e90b3942d06b2326fba0403ec24fe912372936",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^2.0",
+                "php": "^7.2 || ^8.0",
+                "phpstan/phpstan": "^1.9.0 || ^2.0"
+            },
+            "require-dev": {
+                "composer/composer": "^2.0",
+                "php-parallel-lint/php-parallel-lint": "^1.2.0",
+                "phpstan/phpstan-strict-rules": "^0.11 || ^0.12 || ^1.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "PHPStan\\ExtensionInstaller\\Plugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\ExtensionInstaller\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Composer plugin for automatic installation of PHPStan extensions",
+            "keywords": [
+                "dev",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/phpstan/extension-installer/issues",
+                "source": "https://github.com/phpstan/extension-installer/tree/1.4.3"
+            },
+            "time": "2024-09-04T20:21:43+00:00"
+        },
+        {
+            "name": "phpstan/phpstan",
+            "version": "2.1.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan.git",
+                "reference": "6eaec7c6c9e90dcfe46ad1e1ffa5171e2dab641c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/6eaec7c6c9e90dcfe46ad1e1ffa5171e2dab641c",
+                "reference": "6eaec7c6c9e90dcfe46ad1e1ffa5171e2dab641c",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4|^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan-shim": "*"
+            },
+            "bin": [
+                "phpstan",
+                "phpstan.phar"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPStan - PHP Static Analysis Tool",
+            "keywords": [
+                "dev",
+                "static analysis"
+            ],
+            "support": {
+                "docs": "https://phpstan.org/user-guide/getting-started",
+                "forum": "https://github.com/phpstan/phpstan/discussions",
+                "issues": "https://github.com/phpstan/phpstan/issues",
+                "security": "https://github.com/phpstan/phpstan/security/policy",
+                "source": "https://github.com/phpstan/phpstan-src"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/ondrejmirtes",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/phpstan",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-02-19T15:46:42+00:00"
+        },
+        {
+            "name": "phpstan/phpstan-phpunit",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan-phpunit.git",
+                "reference": "d09e152f403c843998d7a52b5d87040c937525dd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan-phpunit/zipball/d09e152f403c843998d7a52b5d87040c937525dd",
+                "reference": "d09e152f403c843998d7a52b5d87040c937525dd",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0",
+                "phpstan/phpstan": "^2.0.4"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<7.0"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/phpstan-strict-rules": "^2.0",
+                "phpunit/phpunit": "^9.6"
+            },
+            "type": "phpstan-extension",
+            "extra": {
+                "phpstan": {
+                    "includes": [
+                        "extension.neon",
+                        "rules.neon"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPUnit extensions and rules for PHPStan",
+            "support": {
+                "issues": "https://github.com/phpstan/phpstan-phpunit/issues",
+                "source": "https://github.com/phpstan/phpstan-phpunit/tree/2.0.4"
+            },
+            "time": "2025-01-22T13:07:38+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -1702,7 +1859,8 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=7.4"
+        "php": ">=7.4",
+        "ext-json": "*"
     },
     "platform-dev": {},
     "plugin-api-version": "2.6.0"

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,7 @@
+parameters:
+	ignoreErrors:
+		-
+			message: '#^Dead catch \- ValueError is never thrown in the try block\.$#'
+			identifier: catch.neverThrown
+			count: 1
+			path: src/Altcha.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,8 @@
+includes:
+    - phpstan-baseline.neon
+
+parameters:
+    level: max
+    paths:
+        - src
+        - tests

--- a/src/Algorithm.php
+++ b/src/Algorithm.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace AltchaOrg\Altcha;
 
 class Algorithm

--- a/src/Algorithm.php
+++ b/src/Algorithm.php
@@ -4,7 +4,7 @@ namespace AltchaOrg\Altcha;
 
 class Algorithm
 {
-    const SHA1 = 'SHA-1';
-    const SHA256 = 'SHA-256';
-    const SHA512 = 'SHA-512';
+    public const SHA1 = 'SHA-1';
+    public const SHA256 = 'SHA-256';
+    public const SHA512 = 'SHA-512';
 }

--- a/src/Altcha.php
+++ b/src/Altcha.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace AltchaOrg\Altcha;
 
 use InvalidArgumentException;

--- a/src/Altcha.php
+++ b/src/Altcha.php
@@ -62,7 +62,7 @@ class Altcha
 
     private static function decodePayload($payload)
     {
-        $decoded = base64_decode($payload);
+        $decoded = base64_decode($payload, true);
 
         if (!$decoded) {
             return null;

--- a/src/Altcha.php
+++ b/src/Altcha.php
@@ -6,9 +6,9 @@ use InvalidArgumentException;
 
 class Altcha
 {
-    const DEFAULT_MAX_NUMBER = 1e6;
-    const DEFAULT_SALT_LENGTH = 12;
-    const DEFAULT_ALGORITHM = Algorithm::SHA256;
+    public const DEFAULT_MAX_NUMBER  = 1e6;
+    public const DEFAULT_SALT_LENGTH = 12;
+    public const DEFAULT_ALGORITHM = Algorithm::SHA256;
 
     private static function randomBytes($length)
     {

--- a/src/BaseChallengeOptions.php
+++ b/src/BaseChallengeOptions.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AltchaOrg\Altcha;
+
+/**
+ * @phpstan-type ChallengeParams array<string, null|scalar>
+ */
+class BaseChallengeOptions
+{
+    public const DEFAULT_MAX_NUMBER = 1000000;
+
+    public string $algorithm;
+    public int $maxNumber;
+    public string $hmacKey;
+    public string $salt;
+    public int $number;
+    public ?\DateTimeInterface $expires;
+
+    /** @var array<array-key, null|scalar> */
+    public array $params;
+
+    /**
+     * Options for creation of a new challenge.
+     * @see ChallengeOptions for options with sane defaults.
+     *
+     * @param ChallengeParams $params
+     */
+    public function __construct(
+        string $algorithm,
+        string $hmacKey,
+        int $maxNumber,
+        ?\DateTimeInterface $expires,
+        string $salt,
+        int $number,
+        array $params
+    ) {
+        $this->algorithm = $algorithm;
+        $this->hmacKey = $hmacKey;
+        $this->maxNumber = $maxNumber;
+        $this->expires = $expires;
+        $this->salt = $salt;
+        $this->number = $number;
+        $this->params = $params;
+
+        if ($expires) {
+            $params['expires'] = $expires->getTimestamp();
+        }
+
+        if (!empty($params)) {
+            $this->salt .= '?' . http_build_query($params);
+        }
+    }
+}

--- a/src/Challenge.php
+++ b/src/Challenge.php
@@ -8,11 +8,11 @@ class Challenge
 {
     public string $algorithm;
     public string $challenge;
-    public float $maxnumber;
+    public int $maxnumber;
     public string $salt;
     public string $signature;
 
-    public function __construct(string $algorithm, string $challenge, float $maxNumber, string $salt, string $signature)
+    public function __construct(string $algorithm, string $challenge, int $maxNumber, string $salt, string $signature)
     {
         $this->algorithm = $algorithm;
         $this->challenge = $challenge;

--- a/src/Challenge.php
+++ b/src/Challenge.php
@@ -1,16 +1,18 @@
 <?php
 
+declare(strict_types=1);
+
 namespace AltchaOrg\Altcha;
 
 class Challenge
 {
-    public $algorithm;
-    public $challenge;
-    public $maxnumber;
-    public $salt;
-    public $signature;
+    public string $algorithm;
+    public string $challenge;
+    public float $maxnumber;
+    public string $salt;
+    public string $signature;
 
-    public function __construct($algorithm, $challenge, $maxNumber, $salt, $signature)
+    public function __construct(string $algorithm, string $challenge, float $maxNumber, string $salt, string $signature)
     {
         $this->algorithm = $algorithm;
         $this->challenge = $challenge;

--- a/src/ChallengeOptions.php
+++ b/src/ChallengeOptions.php
@@ -1,17 +1,21 @@
 <?php
 
+declare(strict_types=1);
+
 namespace AltchaOrg\Altcha;
 
 class ChallengeOptions
 {
-    public $algorithm;
-    public $maxNumber;
-    public $saltLength;
-    public $hmacKey;
-    public $salt;
-    public $number;
-    public $expires;
-    public $params;
+    public string $algorithm;
+    public float $maxNumber;
+    public int $saltLength;
+    public string $hmacKey;
+    public string $salt;
+    public int $number;
+    public ?int $expires;
+
+    /** @var array<array-key, null|scalar> */
+    public array $params;
 
     public function __construct($options = [])
     {

--- a/src/ChallengeOptions.php
+++ b/src/ChallengeOptions.php
@@ -4,28 +4,55 @@ declare(strict_types=1);
 
 namespace AltchaOrg\Altcha;
 
-class ChallengeOptions
+/**
+ * @phpstan-import-type ChallengeParams from BaseChallengeOptions
+ */
+class ChallengeOptions extends BaseChallengeOptions
 {
-    public string $algorithm;
-    public float $maxNumber;
-    public int $saltLength;
-    public string $hmacKey;
-    public string $salt;
-    public int $number;
-    public ?int $expires;
+    public const DEFAULT_ALGORITHM = Algorithm::SHA256;
 
-    /** @var array<array-key, null|scalar> */
-    public array $params;
+    private const DEFAULT_SALT_LENGTH = 12;
 
-    public function __construct($options = [])
+    /**
+     * Options for creation of a new challenge with sane defaults.
+     *
+     * @param string                  $hmacKey    Required HMAC key.
+     * @param int                     $maxNumber  Maximum number for the random number generator (default: 1,000,000)
+     * @param string                  $algorithm  Hashing algorithm to use (`SHA-1`, `SHA-256`, `SHA-512`, default:
+     *                                            `SHA-256`).
+     * @param \DateTimeInterface|null $expires    Optional expiration time for the challenge.
+     * @param ChallengeParams         $params     Optional URL-encoded query parameters.
+     * @param int<1, max>             $saltLength Length of the random salt (default: 12 bytes).
+     */
+    public function __construct(
+        string $hmacKey,
+        string $algorithm = self::DEFAULT_ALGORITHM,
+        int $maxNumber = self::DEFAULT_MAX_NUMBER,
+        ?\DateTimeInterface $expires = null,
+        array $params = [],
+        int $saltLength = self::DEFAULT_SALT_LENGTH
+    ) {
+        parent::__construct(
+            $algorithm,
+            $hmacKey,
+            $maxNumber,
+            $expires,
+            bin2hex(self::randomBytes($saltLength)),
+            self::randomInt($maxNumber),
+            $params
+        );
+    }
+
+    private static function randomInt(int $max): int
     {
-        $this->algorithm = $options['algorithm'] ?? Altcha::DEFAULT_ALGORITHM;
-        $this->maxNumber = $options['maxNumber'] ?? Altcha::DEFAULT_MAX_NUMBER;
-        $this->saltLength = $options['saltLength'] ?? Altcha::DEFAULT_SALT_LENGTH;
-        $this->hmacKey = $options['hmacKey'] ?? '';
-        $this->salt = $options['salt'] ?? '';
-        $this->number = $options['number'] ?? 0;
-        $this->expires = $options['expires'] ?? null;
-        $this->params = $options['params'] ?? [];
+        return random_int(0, $max);
+    }
+
+    /**
+     * @param int<1, max> $length
+     */
+    private static function randomBytes(int $length): string
+    {
+        return random_bytes($length);
     }
 }

--- a/src/CheckChallengeOptions.php
+++ b/src/CheckChallengeOptions.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AltchaOrg\Altcha;
+
+class CheckChallengeOptions extends BaseChallengeOptions
+{
+    public function __construct(
+        string $hmacKey,
+        string $algorithm,
+        string $salt,
+        int $number
+    ) {
+        parent::__construct($algorithm, $hmacKey, self::DEFAULT_MAX_NUMBER, null, $salt, $number, []);
+    }
+}

--- a/src/Payload.php
+++ b/src/Payload.php
@@ -1,16 +1,18 @@
 <?php
 
+declare(strict_types=1);
+
 namespace AltchaOrg\Altcha;
 
 class Payload
 {
-    public $algorithm;
-    public $challenge;
-    public $number;
-    public $salt;
-    public $signature;
+    public string $algorithm;
+    public string $challenge;
+    public int $number;
+    public string $salt;
+    public string $signature;
 
-    public function __construct($algorithm, $challenge, $number, $salt, $signature)
+    public function __construct(string $algorithm, string $challenge, int $number, string $salt, string $signature)
     {
         $this->algorithm = $algorithm;
         $this->challenge = $challenge;

--- a/src/ServerSignaturePayload.php
+++ b/src/ServerSignaturePayload.php
@@ -1,15 +1,17 @@
 <?php
 
+declare(strict_types=1);
+
 namespace AltchaOrg\Altcha;
 
 class ServerSignaturePayload
 {
-    public $algorithm;
-    public $verificationData;
-    public $signature;
-    public $verified;
+    public string $algorithm;
+    public string $verificationData;
+    public string $signature;
+    public string $verified;
 
-    public function __construct($algorithm, $verificationData, $signature, $verified)
+    public function __construct(string $algorithm, string $verificationData, string $signature, string $verified)
     {
         $this->algorithm = $algorithm;
         $this->verificationData = $verificationData;

--- a/src/ServerSignaturePayload.php
+++ b/src/ServerSignaturePayload.php
@@ -9,9 +9,9 @@ class ServerSignaturePayload
     public string $algorithm;
     public string $verificationData;
     public string $signature;
-    public string $verified;
+    public bool $verified;
 
-    public function __construct(string $algorithm, string $verificationData, string $signature, string $verified)
+    public function __construct(string $algorithm, string $verificationData, string $signature, bool $verified)
     {
         $this->algorithm = $algorithm;
         $this->verificationData = $verificationData;

--- a/src/ServerSignatureVerification.php
+++ b/src/ServerSignatureVerification.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AltchaOrg\Altcha;
+
+class ServerSignatureVerification
+{
+    public bool $verified;
+    public ?ServerSignatureVerificationData $data;
+
+    public function __construct(bool $verified, ?ServerSignatureVerificationData $data)
+    {
+        $this->verified = $verified;
+        $this->data = $data;
+    }
+}

--- a/src/ServerSignatureVerificationData.php
+++ b/src/ServerSignatureVerificationData.php
@@ -1,19 +1,20 @@
 <?php
 
+declare(strict_types=1);
+
 namespace AltchaOrg\Altcha;
 
 class ServerSignatureVerificationData
 {
-    public $classification;
-    public $country;
-    public $detectedLanguage;
-    public $email;
-    public $expire;
-    public $fields;
-    public $fieldsHash;
-    public $ipAddress;
-    public $reasons;
-    public $score;
-    public $time;
-    public $verified;
+    public string $classification;
+    public string $country;
+    public string $detectedLanguage;
+    public string $email;
+    public int $expire;
+    public array $fields;
+    public string $fieldsHash;
+    public array $reasons;
+    public float $score;
+    public int $time;
+    public bool $verified;
 }

--- a/src/ServerSignatureVerificationData.php
+++ b/src/ServerSignatureVerificationData.php
@@ -11,10 +11,42 @@ class ServerSignatureVerificationData
     public string $detectedLanguage;
     public string $email;
     public int $expire;
+    /** @var array<array-key, mixed> */
     public array $fields;
     public string $fieldsHash;
+    /** @var array<array-key, mixed> */
     public array $reasons;
     public float $score;
     public int $time;
     public bool $verified;
+
+    /**
+     * @param array<array-key, mixed> $fields
+     * @param array<array-key, mixed> $reasons
+     */
+    public function __construct(
+        string $classification,
+        string $country,
+        string $detectedLanguage,
+        string $email,
+        int $expire,
+        array $fields,
+        string $fieldsHash,
+        array $reasons,
+        float $score,
+        int $time,
+        bool $verified
+    ) {
+        $this->classification = $classification;
+        $this->country = $country;
+        $this->detectedLanguage = $detectedLanguage;
+        $this->email = $email;
+        $this->expire = $expire;
+        $this->fields = $fields;
+        $this->fieldsHash = $fieldsHash;
+        $this->reasons = $reasons;
+        $this->score = $score;
+        $this->time = $time;
+        $this->verified = $verified;
+    }
 }

--- a/src/Solution.php
+++ b/src/Solution.php
@@ -1,13 +1,15 @@
 <?php
 
+declare(strict_types=1);
+
 namespace AltchaOrg\Altcha;
 
 class Solution
 {
-    public $number;
-    public $took;
+    public int $number;
+    public float $took;
 
-    public function __construct($number, $took)
+    public function __construct(int $number, float $took)
     {
         $this->number = $number;
         $this->took = $took;


### PR DESCRIPTION
This PR refs #8 to improve validation and use types (where possible).

The most important breaking change is the replacement of creating a challenge using arrays with typed object properties.

This type safety instantly makes the code easier to use and read (it's clear which type the parameters should have and how they should be used).

All public methods are now documented with PHPDoc to improve dev experience in modern IDEs.